### PR TITLE
Add automatic transcription and Markdown generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # video_to_scorm
+
+Generate a simple SCORM package from a video and accompanying subtitles.
+
+## Features
+- Creates an HTML video player packaged as a SCORM 1.2 module.
+- Accepts either a local video file or an external video URL.
+- If a `.srt` subtitle file is provided, a Markdown transcript is generated.
+- If no `.srt` is provided for a local video, the script transcribes the video
+  using [Whisper](https://github.com/openai/whisper) and saves both `.srt` and
+  Markdown transcripts.
+
+## Usage
+```bash
+python video_to_scorm.py --video path/to/video.mp4 --output output_dir
+```
+
+Optional arguments:
+- `--subtitles path/to/subtitles.srt` – use an existing subtitle file.
+- `--video-url URL` – use a remote video instead of a local file (requires subtitles).
+- `--title "Lesson Title"` – override the default lesson title.
+
+The output directory will contain the SCORM package and any generated transcripts.

--- a/video_to_scorm.py
+++ b/video_to_scorm.py
@@ -48,6 +48,69 @@ def time_to_seconds(time_str):
     return int(h) * 3600 + int(m) * 60 + int(s)
 
 # ----------------------------
+# TIMESTAMP HELPERS
+# ----------------------------
+def seconds_to_timestamp(seconds):
+    """Convert float seconds to SRT timestamp."""
+    td = timedelta(seconds=seconds)
+    total_seconds = int(td.total_seconds())
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    secs = total_seconds % 60
+    milliseconds = int(round((seconds - total_seconds) * 1000))
+    return f"{hours:02}:{minutes:02}:{secs:02},{milliseconds:03}"
+
+
+# ----------------------------
+# TRANSCRIBE VIDEO
+# ----------------------------
+def transcribe_to_srt(video_path, srt_path):
+    """Transcribe ``video_path`` using Whisper and save as ``srt_path``.
+
+    Returns the transcript structure compatible with ``parse_srt``.
+    """
+
+    if whisper is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("Whisper is required for auto-transcription but is not installed")
+
+    print("🎤 No .srt provided → transcribing video with Whisper...")
+    model = whisper.load_model("base")
+    result = model.transcribe(str(video_path))
+
+    transcript = []
+    lines = []
+    for i, seg in enumerate(result.get("segments", []), start=1):
+        start = seconds_to_timestamp(seg["start"])
+        end = seconds_to_timestamp(seg["end"])
+        text = seg.get("text", "").strip()
+        lines.append(f"{i}\n{start} --> {end}\n{text}\n")
+        transcript.append({
+            "index": i,
+            "start": start,
+            "end": end,
+            "start_seconds": int(seg["start"]),
+            "text": text,
+        })
+
+    with open(srt_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    print(f"📝 Saved auto-generated subtitles: {srt_path}")
+
+    return transcript
+
+
+# ----------------------------
+# GENERATE MARKDOWN TRANSCRIPT
+# ----------------------------
+def generate_markdown(transcript, md_path):
+    """Write ``transcript`` to ``md_path`` in a simple Markdown format."""
+
+    with open(md_path, "w", encoding="utf-8") as f:
+        for entry in transcript:
+            f.write(f"- [{entry['start']}] {entry['text']}\n")
+    return md_path
+
+# ----------------------------
 # LOAD CUSTOM SECTIONS
 # ----------------------------
 def load_sections(sections_path, transcript):
@@ -201,10 +264,21 @@ def main():
     video_src = args.video_url if is_url else Path(args.video)
 
     # Subtitle handling
-    if not args.subtitles:
-        parser.error("When using --video-url, please provide --subtitles pointing to a matching .srt")
-    srt_path = Path(args.subtitles)
-    transcript = parse_srt(srt_path)
+    if args.subtitles:
+        srt_path = Path(args.subtitles)
+        transcript = parse_srt(srt_path)
+    else:
+        if is_url:
+            parser.error(
+                "When using --video-url without subtitles, auto-transcription is not supported"
+            )
+        srt_path = output_dir / f"{Path(video_src).stem}.srt"
+        transcript = transcribe_to_srt(video_src, srt_path)
+
+    # Always emit a Markdown transcript alongside the subtitles
+    md_path = srt_path.with_suffix(".md")
+    generate_markdown(transcript, md_path)
+    print(f"📄 Markdown transcript: {md_path}")
 
     # Load custom sections if available
     sections_path = srt_path.with_suffix(".sections")


### PR DESCRIPTION
## Summary
- Add helper utilities to transcribe videos with Whisper and to emit Markdown transcripts
- Automatically transcribe local videos into `.srt` and Markdown when subtitles are missing
- Update README with usage instructions and new behavior

## Testing
- `python -m py_compile video_to_scorm.py`
- `python video_to_scorm.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68af785112a48332b2806a033a11a5f5