### PR TITLE
Add automatic transcription and section file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Generate a simple SCORM package from a video and accompanying subtitles.
 ## Features
 - Creates an HTML video player packaged as a SCORM 1.2 module.
 - Accepts either a local video file or an external video URL.
-- If a `.srt` subtitle file is provided, a Markdown transcript is generated.
-- If no `.srt` is provided for a local video, the script transcribes the video
-  using [Whisper](https://github.com/openai/whisper) and saves both `.srt` and
-  Markdown transcripts.
+- Generates a Markdown transcript alongside any supplied subtitles.
+- When a local video lacks subtitles, automatically transcribes it with
+  [Whisper](https://github.com/openai/whisper) and emits both `.srt` and
+  Markdown transcript files.
 - Emits a companion `.sections` file with generic section titles based on a
   configurable interval.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # video_to_scorm
+
+Generate a simple SCORM package from a video and accompanying subtitles.
+
+## Features
+- Creates an HTML video player packaged as a SCORM 1.2 module.
+- Accepts either a local video file or an external video URL.
+- If a `.srt` subtitle file is provided, a Markdown transcript is generated.
+- If no `.srt` is provided for a local video, the script transcribes the video
+  using [Whisper](https://github.com/openai/whisper) and saves both `.srt` and
+  Markdown transcripts.
+- Emits a companion `.sections` file with generic section titles based on a
+  configurable interval.
+
+## Usage
+```bash
+python video_to_scorm.py --video path/to/video.mp4 --output output_dir
+```
+
+Optional arguments:
+- `--subtitles path/to/subtitles.srt` – use an existing subtitle file.
+- `--video-url URL` – use a remote video instead of a local file (requires subtitles).
+- `--title "Lesson Title"` – override the default lesson title.
+- `--interval SECONDS` – interval in seconds for auto-generated sections (default 300).
+
+The output directory will contain the SCORM package and any generated transcripts.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Generate a simple SCORM package from a video and accompanying subtitles.
 ## Features
 - Creates an HTML video player packaged as a SCORM 1.2 module.
 - Accepts either a local video file or an external video URL.
-- Generates a Markdown transcript alongside any supplied subtitles.
-- When a local video lacks subtitles, automatically transcribes it with
-  [Whisper](https://github.com/openai/whisper) and emits both `.srt` and
-  Markdown transcript files.
+- If a `.srt` subtitle file is provided, a Markdown transcript is generated.
+- If no `.srt` is provided for a local video, the script transcribes the video
+  using [Whisper](https://github.com/openai/whisper) and saves both `.srt` and
+  Markdown transcripts.
 - Emits a companion `.sections` file with generic section titles based on a
   configurable interval.
 


### PR DESCRIPTION
## Summary
- Auto-generate `.sections` files alongside subtitles with generic interval-based titles
- Document `.sections` creation and interval configuration in README

## Testing
- `python -m py_compile video_to_scorm.py`
- `python video_to_scorm.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68af785112a48332b2806a033a11a5f5