### PR TITLE
Ensure .sections file is included in SCORM output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ Generate a simple SCORM package from a video and accompanying subtitles.
 - If no `.srt` is provided for a local video, the script transcribes the video
   using [Whisper](https://github.com/openai/whisper) and saves both `.srt` and
   Markdown transcripts.
-codex/transcribe-video-to-.srt-and-markdown-4h43cq
-- Emits a companion `.sections` file with generic section titles based on a
-  configurable interval.
+- Emits a companion `.sections` file in the output directory (named after the
+  output folder) with generic section titles based on a configurable interval.
 ## Usage
 ```bash
 python video_to_scorm.py --video path/to/video.mp4 --output output_dir
@@ -21,7 +20,7 @@ Optional arguments:
 - `--subtitles path/to/subtitles.srt` – use an existing subtitle file.
 - `--video-url URL` – use a remote video instead of a local file (requires subtitles).
 - `--title "Lesson Title"` – override the default lesson title.
-codex/transcribe-video-to-.srt-and-markdown-4h43cq
 - `--interval SECONDS` – interval in seconds for auto-generated sections (default 300).
 
-The output directory will contain the SCORM package and any generated transcripts.
+The output directory will contain the SCORM package plus the `.srt`, `.md`, and
+`.sections` files.


### PR DESCRIPTION
## Summary
- Copy provided subtitles into the output directory and auto-generate a `.sections` file when missing
- Save the sections metadata using the output folder name so it is bundled inside the SCORM package
- Document `.sections` file behaviour and inclusion in the package

## Testing
- `python -m py_compile video_to_scorm.py`
- `python video_to_scorm.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68af94726f648332922045d7a4671562