### PR TITLE
Add two-step video to SCORM workflow with quiz generation

### DIFF
--- a/templates/quiz_template.html
+++ b/templates/quiz_template.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{TITLE}}</title>
+  <link rel="stylesheet" href="branding.css" />
+  <script>
+    function submitQuiz() {
+      const answer = document.querySelector('input[name="answer"]:checked');
+      if (!answer) {
+        alert('Please select an option.');
+        return;
+      }
+      const score = answer.value === 'correct' ? 100 : 0;
+      try {
+        if (window.parent && window.parent.API) {
+          const API = window.parent.API;
+          API.LMSInitialize('');
+          API.LMSSetValue('cmi.core.score.raw', score.toString());
+          API.LMSSetValue('cmi.core.lesson_status', score === 100 ? 'passed' : 'failed');
+          API.LMSCommit('');
+          API.LMSFinish('');
+        }
+      } catch (e) {
+        // SCORM API not available
+      }
+      alert('Your score: ' + score);
+    }
+  </script>
+</head>
+<body>
+  <h1>{{QUESTION}}</h1>
+  <form>
+    {{OPTIONS}}
+  </form>
+  <button type="button" onclick="submitQuiz()">Submit</button>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Support a two-stage process: `prepare` to create subtitles, markdown, and sections; `package` to bundle assets with a video URL
- Generate quizzes from markdown and include them in the SCORM manifest
- Provide a quiz HTML template for SCORM-compliant scoring

## Testing
- `python -m py_compile video_to_scorm.py`
- `python video_to_scorm.py --help`
- `python video_to_scorm.py prepare --help`
- `python video_to_scorm.py package --help`


------
https://chatgpt.com/codex/tasks/task_b_68af996c3c408332888d4a1861778d61